### PR TITLE
Fixed method `pop`

### DIFF
--- a/JavaScript/6-doubly-proto.js
+++ b/JavaScript/6-doubly-proto.js
@@ -24,7 +24,6 @@ LinkedList.prototype.pop = function() {
   else this.first = null;
   node.list = null;
   node.prev = null;
-  node.next = null;
   this.length--;
   return node.data;
 };

--- a/JavaScript/6-doubly-proto.js
+++ b/JavaScript/6-doubly-proto.js
@@ -21,6 +21,7 @@ LinkedList.prototype.pop = function() {
   const node = this.last;
   this.last = node.prev;
   if (this.last) this.last.next = null;
+  else this.first = null;
   node.list = null;
   node.prev = null;
   node.next = null;


### PR DESCRIPTION
1. If we don‘t patch the field `first` in the `list`, after removing first element from the one, it still has the reference on removed first element.
2. When we push new element in the `list`, there is creating a new instance of `Node` with the field `next`, which has the value `null`. Aslo when we remove any element from  the `list`, we patch the field `next` of the element before the last,  by reassignment it with the value `null`. So we don‘t need to patch the field `next` with the value `null` in the removed element, because it already has this field with the same value.